### PR TITLE
socket.once('end'

### DIFF
--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -24,6 +24,8 @@ test('createServer() & createConnection()', function (t) {
     clientSocket.write('beep');
     clientSocket.once('data', function (chunk) {
       t.equal(chunk.toString(), 'boop');
+    });
+    clientSocket.once('end', function () {
       server.close(t.end.bind(t));
     });
   });


### PR DESCRIPTION
Hey @iefserge - I added this test but it doesn't pass.

It seem that the `onend` method isn't called properly [here](https://github.com/kesla/runtime-node-net/blob/f0f5e37b7d3f69478fcc72a3e871343c35101dbd/lib/socket.js#L24-L26).

(I tried adding a test for this in runtime but https://github.com/runtimejs/runtime/issues/50 got me confused how to run a test)
