### PR TITLE
Fix wrapping http requests in net server

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@ const Server = require('./lib/server');
 const Socket = require('./lib/socket');
 const isIp = require('is-ip');
 
+const wrapper = new Server(function(servsocket) {
+  servsocket.once('data', function(data) {
+    servsocket.end();
+    wrapper.close();
+  });
+});
+wrapper.listen(0, function() {
+  const initsocket = connect(wrapper.address().port);
+  initsocket.write('open');
+  initsocket.close();
+});
+
 module.exports.Server = Server;
 module.exports.createServer = function (cb) {
   return new Server(cb);


### PR DESCRIPTION
This pull request makes a change in index.js that prevents having to wrap `http` (like get, etc) in a net server for it to work. Now you can just `http.get` and `http.createServer` without putting inside a `runtime-node-net` server.
