### PR TITLE
Add runtimejs as a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "homepage": "https://github.com/kesla/runtime-node-net#readme",
   "dependencies": {
     "es6-class": "^0.9.5",
-    "is-ip": "^1.0.0"
+    "is-ip": "^1.0.0",
+    "runtimejs": "^0.1.11"
   },
   "devDependencies": {
     "http-node": "0.0.2",
     "runtime-tools": "^0.5.0",
     "runtimeify": "^0.3.1",
-    "runtimejs": "^0.1.11",
     "split": "^1.0.0",
     "tap-finished": "0.0.1",
     "tape": "^4.0.0"


### PR DESCRIPTION
Now that runtimeify includes `runtime-node-net`, when you install runtimeify as a global package, you recieve an error of there being no runtimejs for this module. There must some other way to fix this, right? (peerDependency, maybe?)
